### PR TITLE
restrict users to post only once in 24 hours

### DIFF
--- a/project/Streamline/Controller/FeedViewController.swift
+++ b/project/Streamline/Controller/FeedViewController.swift
@@ -196,7 +196,6 @@ extension FeedViewController: SPTAudioStreamingDelegate, SPTAudioStreamingPlayba
     }
     
     func audioStreaming(_ audioStreaming: SPTAudioStreamingController!, didStopPlayingTrack trackUri: String!) {
-        
         let posts = DB.posts
         let toPlayIndex = (State.nowPlayingIndex! + 1) % posts.count
         let post = posts[toPlayIndex]

--- a/project/Streamline/Controller/FeedViewController.swift
+++ b/project/Streamline/Controller/FeedViewController.swift
@@ -245,22 +245,33 @@ extension FeedViewController: NowPlayingProtocol, FeedViewDelegate {
         searchView.searchBar.text = ""
         searchView.delegate = self
         
-        /* Code to limit user to one song a day and delete user pid if it has been 12 hours */
+        /* Code to limit user to one song a day and delete user pid if it has been 24 hours */
+        if let timePosted = DB.currentUser.timePosted {
+            if (Date().timeIntervalSince1970 - timePosted <= 86400) {
+                let alert = Utils.createAlert(warningMessage: "Sorry! You can only post one song a day. Try post again later")
+                self.present(alert, animated: true, completion: nil)
+            }
+        } else {
+            self.createSearchView()
+        }
+        
+        
 //        DB.currentUser.getPID {
 //            if DB.currentUser.pid == "" {
 //                self.createSearchView()
 //            } else {
-//                //TODO: Check if song is past deadline
-//                DB.getSinglePost(pid: DB.currentUser.pid, withBlock: { (post) in
-//                    if (Date().timeIntervalSince1970 - post.timePosted >= 43200) {
-//                        DB.currentUser.createPost(pid: "")
-//                        self.createSearchView()
-//                    }
-//                })
+////                TODO: Check if song is past deadline
+//                
+////                DB.getSinglePost(pid: DB.currentUser.pid, withBlock: { (post) in
+////                    if (Date().timeIntervalSince1970 - post.timePosted >= 43200) {
+////                        DB.currentUser.createPost(pid: "")
+////                        self.createSearchView()
+////                    }
+////                })
 //            }
         
         //Create search modal
-        createSearchView()
+//        self.createSearchView()
     }
     
     //Handles player button pressed

--- a/project/Streamline/Model/Post.swift
+++ b/project/Streamline/Model/Post.swift
@@ -9,14 +9,15 @@
 import Haneke
 
 class Post {
-    var pid         : String!
-    var uid         : String!
-    var username    : String!
-    var timePosted  : TimeInterval!
-    var trackId     : String!
-    var songTitle   : String!
-    var artist      : String!
-    var imageUrl    : String!
+    var pid            : String!
+    var uid            : String!
+    var username       : String!
+    var timePosted     : TimeInterval!
+    var trackId        : String!
+    var songTitle      : String!
+    var artist         : String!
+    var imageUrl       : String!
+    var profileImageURL: String!
     
     init(uid:           String,
          username:      String,
@@ -24,7 +25,8 @@ class Post {
          trackId:       String,
          songTitle:     String,
          artist:        String,
-         imageUrl:      String) {
+         imageUrl:      String,
+         profileImageURL:  String) {
         self.uid        = uid
         self.username   = username
         self.timePosted = timePosted
@@ -32,23 +34,26 @@ class Post {
         self.songTitle  = songTitle
         self.artist     = artist
         self.imageUrl   = imageUrl
+        self.profileImageURL = profileImageURL
     }
     
     convenience init(pid: String, postDict: [String: Any]) {
-        let uid         = postDict["uid"]           as! String
-        let username    = postDict["displayName"]   as! String
-        let imageUrl    = postDict["imageUrl"]      as! String
-        let timePosted  = postDict["timePosted"]    as! TimeInterval
-        let songTitle   = postDict["songTitle"]     as! String
-        let artist      = postDict["artist"]        as! String
-        let trackId     = postDict["trackId"]       as! String
+        let uid         = postDict["uid"]              as! String
+        let username    = postDict["displayName"]      as! String
+        let imageUrl    = postDict["imageUrl"]         as! String
+        let timePosted  = postDict["timePosted"]       as! TimeInterval
+        let songTitle   = postDict["songTitle"]        as! String
+        let artist      = postDict["artist"]           as! String
+        let trackId     = postDict["trackId"]          as! String
+        let profImage   = postDict["profileImageURL"]  as! String
         self.init(uid: uid,
                   username: username,
                   timePosted: timePosted,
                   trackId: trackId,
                   songTitle: songTitle,
                   artist: artist,
-                  imageUrl: imageUrl)
+                  imageUrl: imageUrl,
+                  profileImageURL: profImage)
         self.pid = pid
     }
     

--- a/project/Streamline/Model/User.swift
+++ b/project/Streamline/Model/User.swift
@@ -9,10 +9,11 @@
 import Haneke
 
 class User {
-    var pid     : String!
-    var uid     : String!
-    var username: String!
-    var imageUrl: String!
+    var pid        : String!
+    var uid        : String!
+    var username   : String!
+    var imageUrl   : String!
+    var timePosted : TimeInterval?
     
     //Username needs to be set from the view controllers
     init(uid: String) {
@@ -20,15 +21,17 @@ class User {
     }
     
     // Get the users current pid from the database
-    func getPID(withBlock: @escaping () -> ()){
-        DB.retrievePID(uid: self.uid) { (pid) in
-            self.pid = pid
-            withBlock()
-        }
-    }
+//    func getPID(withBlock: @escaping () -> ()){
+//        DB.retrievePID(uid: self.uid) { (pid) in
+//            self.pid = pid
+//
+//            withBlock()
+//        }
+//    }
     
-    func createPost(pid: String){
-        DB.userPost(uid: self.uid, pid: pid)
+    func createPost(pid: String, timePosted: TimeInterval){
+        DB.userPost(uid: self.uid, pid: pid, timePosted: timePosted)
+        self.timePosted = timePosted
     }
     
     func getProfileImage(withBlock: @escaping (UIImage) -> ()) {

--- a/project/Streamline/Utils/DB.swift
+++ b/project/Streamline/Utils/DB.swift
@@ -99,9 +99,9 @@ struct DB {
     
     // Sets the users post pid in the database
     static func userPost(uid: String, pid: String, timePosted: TimeInterval) {
-        let ref = Database.database().reference().child("users").child(uid) //.child("pid")
-        let dict = ["pid":pid, "timePosted":timePosted] as [String : Any]
-        ref.setValue(dict)
+        let ref = Database.database().reference().child("users").child(uid)
+        ref.child("pid").setValue(pid)
+        ref.child("timePosted").setValue(timePosted)
     }
     
     // Gets a single post with the user id

--- a/project/Streamline/Utils/DB.swift
+++ b/project/Streamline/Utils/DB.swift
@@ -92,7 +92,8 @@ struct DB {
                                    "timePosted": post.timePosted,
                                    "songTitle": post.songTitle,
                                    "artist": post.artist,
-                                   "trackId": post.trackId]
+                                   "trackId": post.trackId,
+                                   "profileImageURL": currentUser.imageUrl]
         ref.setValue(dict)
     }
     

--- a/project/Streamline/Utils/DB.swift
+++ b/project/Streamline/Utils/DB.swift
@@ -97,19 +97,20 @@ struct DB {
     }
     
     // Sets the users post pid in the database
-    static func userPost(uid: String, pid: String) {
-        var ref = Database.database().reference().child("users").child(uid).child("pid")
-        ref.setValue(pid)
+    static func userPost(uid: String, pid: String, timePosted: TimeInterval) {
+        let ref = Database.database().reference().child("users").child(uid) //.child("pid")
+        let dict = ["pid":pid, "timePosted":timePosted] as [String : Any]
+        ref.setValue(dict)
     }
     
     // Gets a single post with the user id
-    static func getSinglePost(pid: String, withBlock: @escaping (Post) -> ()) {
-        var ref = Database.database().reference().child("posts").child(pid)
-        ref.observeSingleEvent(of: .value) { (snapshot, error) in
-            let post = Post(pid: pid, postDict: snapshot.value as! [String : Any])
-            withBlock(post)
-        }
-    }
+//    static func getSinglePost(pid: String, withBlock: @escaping (Post) -> ()) {
+//        var ref = Database.database().reference().child("posts").child(pid)
+//        ref.observeSingleEvent(of: .value) { (snapshot, error) in
+//            let post = Post(pid: pid, postDict: snapshot.value as! [String : Any])
+//            withBlock(post)
+//        }
+//    }
     
     //Sorts the posts by time stamp
     static func sortPosts() {

--- a/project/Streamline/Utils/SpotifyWeb.swift
+++ b/project/Streamline/Utils/SpotifyWeb.swift
@@ -19,7 +19,7 @@ class SpotifyWeb {
         Alamofire.request("https://api.spotify.com/v1/me", headers: headers).responseJSON(completionHandler: { (response) in
             let initialJsonResponse = response.result.value as? NSDictionary
             if let jsonResponse = initialJsonResponse {
-                var username : String = "Anonymous User"
+                let username : String = "Anonymous User"
                 print((jsonResponse["images"] as! NSArray).count)
                 var imageURL = ""
                 if (jsonResponse["images"] as! NSArray).count == 0 {
@@ -27,7 +27,7 @@ class SpotifyWeb {
                 } else {
                     imageURL = ((jsonResponse["images"] as! NSArray)[0] as! NSDictionary)["url"] as! String
                 }
-                var usernameJson = jsonResponse["display_name"]
+                let usernameJson = jsonResponse["display_name"]
                 if let x = jsonResponse["display_name"] as? String {
                     withBlock(x, imageURL)
                 } else {

--- a/project/Streamline/Utils/Utils.swift
+++ b/project/Streamline/Utils/Utils.swift
@@ -42,6 +42,15 @@ class Utils {
         
         return CGRect(x: sqx, y: y, width: squareDim, height: squareDim)
     }
+    
+    // presents popup alert
+    static func createAlert(warningMessage: String) -> UIAlertController {
+        let alert = UIAlertController(title: "WARNING:",
+                                      message: warningMessage,
+                                      preferredStyle: UIAlertControllerStyle.alert)
+        alert.addAction(UIAlertAction(title: "OK", style: UIAlertActionStyle.default, handler: nil))
+        return alert
+    }
 
 }
 

--- a/project/Streamline/View/SearchView.swift
+++ b/project/Streamline/View/SearchView.swift
@@ -107,7 +107,8 @@ class SearchView: UIView {
                             trackId: track.identifier,
                             songTitle: track.name,
                             artist: artist!,
-                            imageUrl: track.album.largestCover.imageURL.absoluteString)
+                            imageUrl: track.album.largestCover.imageURL.absoluteString,
+                            profileImageURL: DB.currentUser.imageUrl)
             
             DB.createPost(post: post, user: DB.currentUser)
             u.createPost(pid: post.pid, timePosted: post.timePosted)

--- a/project/Streamline/View/SearchView.swift
+++ b/project/Streamline/View/SearchView.swift
@@ -110,7 +110,7 @@ class SearchView: UIView {
                             imageUrl: track.album.largestCover.imageURL.absoluteString)
             
             DB.createPost(post: post, user: DB.currentUser)
-            u.createPost(pid: post.pid)
+            u.createPost(pid: post.pid, timePosted: post.timePosted)
             delegate?.dismissView()
         }
     }


### PR DESCRIPTION
**CHANGES MADE** 

- added alert to notify users that they can only post once in 24 hours

- prevents search modal from popping up, if the user has already posted within 24 hours

- changed method such this functionality is dependent on stored _timestamp_, and not the post id (don't have to pull the post from firebase; allows for server  cleanup in the future)

- added timePosted field to the User model class

- project now updates timePosted and pid field under the User branch in firebase when user makes a new post


**TODO:**
- change the alert text to display something more coherent (i just remembered right now that what i typed didn't make 100% grammatical sense)

- right now the restriction only works within the same app session — if the app closes and reopens, the user can add another song. this is because of the way DB.currentUser is being created (i couldn't find _where_ DB.currentUser was set after the LoginVC decides to take us directly to the Feed if the user was logged in before. we need to update DB.currentUser to grab the timePosted field that's stored in firebase